### PR TITLE
Removing hardcoded black value from the Vue icons and set root fill and color to `currentColor`

### DIFF
--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -10,10 +10,12 @@ import {
 </script>
 
 <template>
-  <Database />
-  <OxygenTank color="red" height="36" width="36" />
-  <BloodBag />
-  <BloodBagFilled24px />
+  <div style="color: #1E441E">
+    <Database />
+  </div>
+    <OxygenTank color="red" fill="currentColor" height="36" width="36" />
+    <BloodBag />
+    <BloodBagFilled24px />
 
   <HealthiconsProvider
     :icon-props="{


### PR DESCRIPTION
Removing all hardcoded color black values from Vue icons and set on root currentColor soo it inherits the color set by the parent. 